### PR TITLE
Add a solid frame color to avoid a weird half-coverage issue on Windows maximized windows

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,7 @@
    "name": "Four Kitchens Theme",
    "theme": {
       "colors": {
+         "frame": [ 53, 170, 78 ],
          "ntp_background": [ 53, 170, 78 ],
          "ntp_text": [ 255, 255, 255 ]
       },


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/1486573/18318531/9cbd8554-74e7-11e6-9dff-be39fd75542f.png)

After:
![image](https://cloud.githubusercontent.com/assets/1486573/18318516/9026811a-74e7-11e6-9893-0fe4c5d19a1b.png)

Sometimes it's the little things.
